### PR TITLE
Fix for "Undefined offset: 26" error

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -582,7 +582,7 @@ class Pdf
      */
     protected function nextHandle()
     {
-        if ($this->_handle>26) {
+        if ($this->_handle>25) {
             throw new \Exception('Ran out of hanldes for input PDFs');
         }
         $chars = range('Z','A');


### PR DESCRIPTION
Zero indexed array produced from range(), with indexes of 0-25 for the
26 characters.