### PR TITLE
Add support for XfdfFile

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -231,7 +231,7 @@ class Pdf
         $this->constrainSingleFile();
         $this->getCommand()
             ->setOperation('fill_form')
-            ->setOperationArgument(is_array($data) ? new FdfFile($data, null, null, null, $encoding) : $data, true);
+            ->setOperationArgument(is_array($data) ? new XfdfFile($data, null, null, null, $encoding) : $data, true);
         if ($dropXfa) {
             $this->dropXfa();
         }

--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -1,0 +1,79 @@
+<?php
+namespace mikehaertl\pdftk;
+
+use mikehaertl\tmp\File;
+
+/**
+ * XfdfFile
+ *
+ * This class represents a temporary XFDF file that can be used to fill a PDF form
+ * with valid unicode characters.
+ *
+ * @author Tomas Holy <holy@interconnect.cz>
+ * @version 0.2.2
+ * @license http://www.opensource.org/licenses/MIT
+ */
+class XfdfFile extends File
+{
+    // XFDF file header
+    const XFDF_HEADER = <<<FDF
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdf xmlns="http://ns.adobe.com/xfdf/" xml:space="preserve">
+<fields>
+FDF;
+
+    // XFDF file footer
+    const XFDF_FOOTER = <<<FDF
+</fields>
+</xfdf>
+FDF;
+
+    /**
+     * Constructor
+     *
+     * @param array $data the form data as name => value
+     * @param string|null $suffix the optional suffix for the tmp file
+     * @param string|null $suffix the optional prefix for the tmp file. If null 'php_tmpfile_' is used.
+     * @param string|null $directory directory where the file should be created. Autodetected if not provided.
+     * @param string|null $encoding of the data. Default is 'UTF-8'.
+     */
+    public function __construct($data, $suffix = null, $prefix = null, $directory = null, $encoding = 'UTF-8')
+    {
+        if ($directory===null) {
+            $directory = self::getTempDir();
+        }
+        $suffix = '.xfdf';
+        $prefix = 'php_pdftk_xfdf_';
+
+        $this->_fileName = tempnam($directory,$prefix);
+        $newName = $this->_fileName.$suffix;
+        rename($this->_fileName, $newName);
+        $this->_fileName = $newName;
+
+        $fields = '';
+        
+        foreach ($data as $key=>$value) {
+            //Initialize variable
+            $field = '';
+
+            //Sanitize input for use in XML
+            $sanitizedKey = htmlentities($key);
+            $sanitizedValue = htmlentities($value);
+            
+            //Make <field> part
+            $field .= '<field name="'.$sanitizedKey.'">'."\n";
+            $field .= '<value>'.$sanitizedValue.'</value>'."\n";
+            $field .= '</field>'."\n";
+            
+            //Add field to $fields
+            $fields .= $field;
+        }
+
+        // Use fwrite, since file_put_contents() messes around with character encoding
+        $fp = fopen($this->_fileName, 'w');
+        fwrite($fp, self::XFDF_HEADER);
+        fwrite($fp, $fields);
+        fwrite($fp, self::XFDF_FOOTER);
+        fclose($fp);
+    }
+}


### PR DESCRIPTION
I experienced problem with filling form with a characters with accents, specifically a "č". I read every issue about that and nothing solve my problem. When I start experimenting with mcpdf, I found out that tool supports only XFDF. When I use mcpdf and xfdf, characters with accents was OK, but there was problem with custom styles on checkbox and radio buttons, mcpdf broke them. 

When I saw good characters with mcpdf and broken with pdftk, I tried everything and from despair I tried last thing, use pdftk with xfdf and voila, everything works, characters and styles on form elements, everything was all right. 

So I write support for generating XFDF file from Array and use that as a default option in Pdf::fillForm.

In fact, I have also some problem with selected font in text inputs which was used in PDF. My PDF form is generated from InDesign and this tool using as default font "Times Roman", I don't have this font installed on my computer, so I thinked, that was problem in this, but after changing font to ArialUnicode I still have problem with character "č" which was missing. At the end of all I found out, that was problem with FDF, when I used XFDF with same data, now was everything OK. 

I attach four screenshots, I fill value "K Říčanům" to input, first screenshot was filled by FDF, second by XFDF. Third is from form.pdf file in tests/ dir, I just need to change font in input from Helvetica to ArialUnicode because I don't Helvetica font which was possible show all characters. And fourth screenshot is for comparison from filledform.pdf file in repository, there is also changed font, here you can also see missing "č".

![snapshot205](https://cloud.githubusercontent.com/assets/5727555/15606420/751b1e52-240c-11e6-86e6-1a07d2ed68e6.png)

![snapshot206](https://cloud.githubusercontent.com/assets/5727555/15606421/751d70a8-240c-11e6-945b-b5f2a9a67745.png)

![snapshot207](https://cloud.githubusercontent.com/assets/5727555/15606652/dac12bc4-240d-11e6-819a-b1b61da690d4.png)

![snapshot208](https://cloud.githubusercontent.com/assets/5727555/15607021/1102887a-2410-11e6-8f91-f475a10dcf6d.png)

Maybe I had to try fix generating of FDF files, but in fact, I don't like that mixture of two character encodings in one file and in XFDF is everything in UTF8. The only thing which is broken are keys with Unicode characters, but I don't need them, so .... I know, I'm selfish. 

And last thing, I spend three days with this crap and there is command which embed font from directory to PDF with filled form and flat that, in correct way with again usability on another computer. Flattening is also broken in pdftk, maybe if I have fonts in system directory, maybe would it be OK, but I don't have more strength for that and I need portability across servers and don't waste time with installing font in system directories.

`gs -sFONTPATH=/dir/with/fonts -o output.pdf -sDEVICE=pdfwrite -dPDFSETTINGS=/prepress input.pdf`