### PR TITLE
File permissions for temp files

### DIFF
--- a/src/FdfFile.php
+++ b/src/FdfFile.php
@@ -80,6 +80,6 @@ FDF;
         fclose($fp);
         
         // Update file permissions to ensure PDFTK can read the file as potentially a different user
-        chmod($this->_filename, 0644);
+        chmod($this->_fileName, 0644);
     }
 }

--- a/src/FdfFile.php
+++ b/src/FdfFile.php
@@ -78,5 +78,8 @@ FDF;
         fwrite($fp, $fields);
         fwrite($fp, self::FDF_FOOTER);
         fclose($fp);
+        
+        // Update file permissions to ensure PDFTK can read the file as potentially a different user
+        chmod($this->_filename, 0644);
     }
 }

--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -87,7 +87,7 @@ FDF;
         fclose($fp);
         
         // Update file permissions to ensure PDFTK can read the file as potentially a different user
-        chmod($this->_filename, 0644);
+        chmod($this->_fileName, 0644);
     }
 
     /**

--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -85,6 +85,9 @@ FDF;
         $this->writeFields($fp, $fields);
         fwrite($fp, self::XFDF_FOOTER);
         fclose($fp);
+        
+        // Update file permissions to ensure PDFTK can read the file as potentially a different user
+        chmod($this->_filename, 0644);
     }
 
     /**


### PR DESCRIPTION
Temp files get given read only permission which is an issue if pdftk is executed as a different user to the PHP web server user