### PR TITLE
Refactor InfoFields parsing

### DIFF
--- a/src/InfoFile.php
+++ b/src/InfoFile.php
@@ -50,7 +50,6 @@ class InfoFile extends File
                 $value = defined('ENT_XML1') ? htmlspecialchars($key, ENT_XML1, 'UTF-8') : htmlspecialchars($key);
                 $key = defined('ENT_XML1') ? htmlspecialchars($value, ENT_XML1, 'UTF-8') : htmlspecialchars($value);
             }
-            
             $fields .= "InfoBegin\nInfoKey: $key\nInfoValue: $value\n";
         }
 

--- a/tests/InfoFieldsTest.php
+++ b/tests/InfoFieldsTest.php
@@ -47,8 +47,27 @@ PageMediaNumber: 5
 PageMediaRotation: 0
 PageMediaRect: 0 0 595 842
 PageMediaDimensions: 595 842
+PageLabelBegin
+PageLabelNewIndex: 1
+PageLabelStart: 1
+PageLabelPrefix: some name 1
+PageLabelNumStyle: NoNumber
+PageLabelBegin
+PageLabelNewIndex: 2
+PageLabelStart: 1
+PageLabelPrefix: some name 2
+PageLabelNumStyle: DecimalArabicNumerals
+PageLabelBegin
+PageLabelNewIndex: 5
+PageLabelStart: 1
+PageLabelNumStyle: LowercaseRomanNumerals
+PageLabelBegin
+PageLabelNewIndex: 6
+PageLabelStart: 1
+PageLabelPrefix: some name 3
+PageLabelNumStyle: NoNumber
 EOD;
-    
+
     protected $_parsedResult = array(
         "Info" => array(
             "CreationDate" => "D:20140709121536+02'00'",
@@ -58,7 +77,6 @@ EOD;
         "PdfID0" => "8b93f76a0b28b720d0dee9a6eb2a780a",
         "PdfID1" => "8b93f76a0b28b720d0dee9a6eb2a780a",
         "NumberOfPages" => "5",
-        "Bookmark" => array(),
         "PageMedia" => array(
             array(
                 "Number" => "1",
@@ -90,7 +108,31 @@ EOD;
                 "Rect" => "0 0 595 842",
                 "Dimensions" => "595 842"
             ),
-        )
-        
+        ),
+        "PageLabel" => array(
+            array(
+                'NewIndex' => '1',
+                'Start' => '1',
+                'Prefix' => 'some name 1',
+                'NumStyle' => 'NoNumber',
+            ),
+            array(
+                'NewIndex' => '2',
+                'Start' => '1',
+                'Prefix' => 'some name 2',
+                'NumStyle' => 'DecimalArabicNumerals',
+            ),
+            array(
+                'NewIndex' => '5',
+                'Start' => '1',
+                'NumStyle' => 'LowercaseRomanNumerals',
+            ),
+            array(
+                'NewIndex' => '6',
+                'Start' => '1',
+                'Prefix' => 'some name 3',
+                'NumStyle' => 'NoNumber',
+            ),
+        ),
     );
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -550,7 +550,6 @@ class PdfTest extends \PHPUnit\Framework\TestCase
     public function testCanGetData()
     {
         $document = $this->getDocument1();
-        
         $pdf = new Pdf($document);
         $data = $pdf->getData();
         $this->assertInstanceOf('\mikehaertl\pdftk\InfoFields', $data);
@@ -664,7 +663,6 @@ EOD;
         "PdfID0" => "8b93f76a0b28b720d0dee9a6eb2a780a",
         "PdfID1" => "8b93f76a0b28b720d0dee9a6eb2a780a",
         "NumberOfPages" => "5",
-        "Bookmark" => array(),
         "PageMedia" => array(
             array(
                 "Number" => "1",


### PR DESCRIPTION
Make parsing metadata more safe so it can now deal with any block that starts with `.*Begin`.