### PR TITLE
Add .gitattributes file with export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.gitignore       export-ignore
+.gitattributes   export-ignore
+.travis.yml      export-ignore
+phpunit.xml.dist export-ignore
+/tests           export-ignore


### PR DESCRIPTION
I'd like to suggest to add a `.gitattributes` file to the root of the project with `export-ignore` rules for development files. 
This will bring down the download size of the library from ~135kb to ~19.7, which is ~85% of size drop. 

Users who want the source file will use it with composer `--prefer-source`, but in normal cases, this will result in a much smaller package size. 

Thank you.