### PR TITLE
makes $start argument nullable and optional.

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -156,7 +156,7 @@ class Pdf
      * or
      *  $files = ['file1.pdf', 'file2.pdf', 'file3.pdf'];
      *  $pdf = new Pdf($files);
-     *  $pdf->cat()                         // all all files, all pages
+     *  $pdf->cat()                         // all files, all pages
      *      ->saveAs('out.pdf');
      *
      * @param int|string|array|null $start the start page number or an array of page

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -161,7 +161,8 @@ class Pdf
      *
      * @param int|string|array|null $start the start page number or an array of page
      * numbers. If an array, the other arguments will be ignored. $start can
-     * also be bigger than $end for pages in reverse order.
+     * also be bigger than $end for pages in reverse order. If $start is null all
+     * pages of all files will be added.
      * @param int|string|null $end the end page number or null for single page
      * (or list if $start is an array)
      * @param string|null $handle the handle of the file to use. Can be null if

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -153,8 +153,13 @@ class Pdf
      *      ->cat('end', 5, 'B')            // pages 5 to end of file B in reverse order
      *      ->cat(null, null, 'B', 'east')  // All pages from file B rotated by 90 degree
      *      ->saveAs('out.pdf');
+     * or
+     *  $files = ['file1.pdf', 'file2.pdf', 'file3.pdf'];
+     *  $pdf = new Pdf($files);
+     *  $pdf->cat()                         // all all files, all pages
+     *      ->saveAs('out.pdf');
      *
-     * @param int|string|array $start the start page number or an array of page
+     * @param int|string|array|null $start the start page number or an array of page
      * numbers. If an array, the other arguments will be ignored. $start can
      * also be bigger than $end for pages in reverse order.
      * @param int|string|null $end the end page number or null for single page
@@ -166,7 +171,7 @@ class Pdf
      * @param string $rotation the rotation to apply to the pages.
      * @return Pdf the pdf instance for method chaining
      */
-    public function cat($start, $end = null, $handle = null, $qualifier = null, $rotation = null)
+    public function cat($start = null, $end = null, $handle = null, $qualifier = null, $rotation = null)
     {
         $this->getCommand()
             ->setOperation('cat')


### PR DESCRIPTION
In order to just merge a couple of pdfs, the only way I found is to use $pdf->cat(null). 
To reflect this behaviour I've updated the docBlock and made the $start argument optional.
Also added an example for usage.