### PR TITLE
fix warning on php 8

### DIFF
--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -77,7 +77,12 @@ FDF;
                     }
                     $target = & $target[$part];
                 }
-                $target[$final] = $sanitizedValue;
+                
+                if (is_string($target)) {
+                    $target = $sanitizedValue;
+                } else {
+                    $target[$final] = $sanitizedValue;
+                }
             }
         }
 


### PR DESCRIPTION
Only the first byte will be assigned to the string offset at /var/www/vendor/mikehaertl/php-pdftk/src/XfdfFile.php:82