### PR TITLE
Set LANG and LC_ALL to C.UTF-8 to overcome locale problems of pdftk.

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -653,6 +653,10 @@ class Pdf
     {
         if ($this->_command === null) {
             $this->_command = new Command;
+            $this->_command->procEnv = [
+                'LANG' => 'C.UTF-8',
+                'LC_ALL' => 'C.UTF-8',
+            ];
         }
         return $this->_command;
     }


### PR DESCRIPTION
pdftk garbles non-ASCII characters otherwise, even with dump_data_utf8
and update_info_utf8.

This addresses the issue #294