### PR TITLE
fix: determine path to tmp folder dynamically due to errors on macos

### DIFF
--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -331,7 +331,8 @@ class PdfTest extends TestCase
         $this->assertFileExists($file);
 
         $tmpFile = (string) $pdf->getTmpFile();
-        $regex = "#pdftk 'A'='$form' 'fill_form' '/tmp/[^ ]+\.xfdf' 'output' '$tmpFile' 'drop_xfa' 'need_appearances'#";
+        $tmpBasePath = substr($tmpFile, 0, strpos($tmpFile, '/', 1));
+        $regex = "#pdftk 'A'='$form' 'fill_form' '$tmpBasePath/[^ ]+\.xfdf' 'output' '$tmpFile' 'drop_xfa' 'need_appearances'#";
         $command = (string) $pdf->getCommand();
         if (phpUnitVersion('<', 9)) {
             $this->assertRegExp($regex, $command);


### PR DESCRIPTION
If running the tests on MacOS a test fails because `/tmp` is always assumed as tmp directory. On MacOS it's something like `/private`. This pr determines the tmp folder based on the path of the pdf tmp file.