### PR TITLE
prevent call to htmlspecialchars on null value

### DIFF
--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -223,6 +223,10 @@ FDF;
      */
     protected function xmlEncode($value)
     {
+        if (null === $value) {
+            return $value;
+        }
+
         return defined('ENT_XML1') ?
             htmlspecialchars($value, ENT_XML1, 'UTF-8') :
             htmlspecialchars($value);


### PR DESCRIPTION
And another one. In newer PHP versions htmlspecialchars complains about `null` values. So we shouldn't call it with the value being `null`.

btw: very nice work!