### PR TITLE
Fix #333 Checkbox support

### DIFF
--- a/src/DataFields.php
+++ b/src/DataFields.php
@@ -49,6 +49,31 @@ class DataFields extends ArrayObject
     }
 
     /**
+     * Get a block with a certain FieldName
+     * 
+     * @param string $name
+     * @return array|false
+     */
+    public function getBlockWithName($name) {
+        $iterator = $this->getIterator();
+        while ($iterator->valid()) {
+            $block = $iterator->current();
+
+            if (! is_array($block)) {
+                break;
+            }
+
+            if (array_key_exists('FieldName', $block) && $block['FieldName'] === $name) {
+                return $block;
+            }
+
+            $iterator->next();
+        }
+
+        return false;
+    }
+
+    /**
      * Parse the output of dump_data_fields into an array.
      *
      * The string to parse can either be a single block of `Xyz:value` lines

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -297,8 +297,12 @@ class Pdf
     {
         $this->constrainSingleFile();
         if (is_array($data)) {
+            $command = clone $this->_command;
+            $dataFields = $this->getDataFields($encoding == 'UTF-8');
+            $this->_command = $command;
+
             $className = '\mikehaertl\pdftk\\' . ($format === 'xfdf' ? 'XfdfFile' : 'FdfFile');
-            $data = new $className($data, null, null, $this->tempDir, $encoding);
+            $data = new $className($data, null, null, $this->tempDir, $encoding, $dataFields);
         }
         $this->getCommand()
             ->setOperation('fill_form')

--- a/src/XfdfFile.php
+++ b/src/XfdfFile.php
@@ -211,7 +211,7 @@ FDF;
             fwrite($fp, "<field name=\"$key\">\n");
             if (!is_array($value)) {
                 $value = array($value);
-            }            
+            }
             if (array_key_exists(0, $value)) {
                 // Numeric keys: single or multi-value field
                 foreach($value as $val) {

--- a/tests/DataFieldsTest.php
+++ b/tests/DataFieldsTest.php
@@ -12,6 +12,25 @@ class DataFieldsTest extends TestCase
         $this->assertEquals($this->_parsedResult, $dataFields->__toArray());
     }
 
+    public function testGetBlockWithExistingName()
+    {
+        $dataFields = new DataFields($this->_testInput);
+        $this->assertEquals($dataFields->getBlockWithName('field2'), array(
+            'FieldType' => 'Text',
+            'FieldName' => 'field2',
+            'FieldNameAlt' => 'field2_alt',
+            'FieldFlags' => 0,
+            'FieldValue' => 'value:with:colons',
+            'FieldJustification' => 'Left',
+        ));
+    }
+
+    public function testGetBlockWithNonExistingName()
+    {
+        $dataFields = new DataFields($this->_testInput);
+        $this->assertEquals($dataFields->getBlockWithName('field0'), false);
+    }
+
     protected $_testInput = <<<DATA
 ---
 FieldType: Text
@@ -82,6 +101,13 @@ FieldJustification: Left
 FieldStateOption: -- Another value with dashes --
 FieldStateOption: Value 2
 FieldStateOption: Value 3
+---
+FieldType: Button
+FieldName: field8
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Yes
+FieldStateOption: Off
 DATA;
 
     protected $_parsedResult = array(
@@ -144,6 +170,16 @@ DATA;
                 'Value 3',
             ),
             'FieldJustification' => 'Left',
+        ),
+        array(
+            'FieldType' => 'Button',
+            'FieldName' => 'field8',
+            'FieldFlags' => 0,
+            'FieldJustification' => 'Left',
+            'FieldStateOption' => array(
+                'Yes',
+                'Off',
+            ),
         ),
     );
 }


### PR DESCRIPTION
This PR adds support for checkboxes. Checkboxes are assumed to always be boolean values when filling the form with data. The boolean values will be replaced with the actual ``FieldStateOption`` necessary to make the checkbox appear checked.

```php
$pdf = new Pdf(resource_path('pdf/handover.pdf'));

        $data = [
            'Text_Field' => 'some text',
            'Checkbox_Unchecked' => false,
            'Checkbox_Checked' => true,
        ];

        $result =
            $pdf->fillForm($data, format: 'fdf')
                ->needAppearances()
                ->send('handover.pdf', true);
```

Currently, the logic doesn't check the type of the parsed block, this may need to be extended in the future if problems occur. As of the examples, I don't expect any if I am not mistaken.

The only part I am unsure of is the handling of the ``fillForm()`` method's logic. In order to keep the command process as is, I cloned and reassigned it and passed the ``DataFields`` object to the XfdfFile/FdfFile object.

Fixes #333 