### PR TITLE
fix: incorrect cat page range (closes #347)

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -181,12 +181,9 @@ class Pdf
         ?string $rotation = null,
     ): self {
         $this->getCommand()
-            ->setOperation('cat');
+            ->setOperation('cat')
+            ->addPageRange(is_null($start) ? "" : $start, $end, $handle, $qualifier, $rotation);
 
-        if ($start !== null) {
-            $this->getCommand()
-                ->addPageRange($start, $end, $handle, $qualifier, $rotation);
-        }
         return $this;
     }
 


### PR DESCRIPTION
In the past versions without strong typing, null was converted to empty string in addPageRange. Strict typing removed this conversion and therefore the issue. 