### PR TITLE
Fix deprecated string increment on non-numeric string in nextHandle() (PHP 8.3+)

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -758,7 +758,11 @@ class Pdf
         $i = $this->_handle++;
         $char = 'A';
         while ($i-- > 0) {
-            $char++;
+            if (function_exists('str_increment')) {
+                $char = str_increment($char);
+            } else {
+                $char++;
+            }
         }
 
         return $char;


### PR DESCRIPTION
On PHP 8.3+ the $char++ operation in nextHandle() triggers "Increment on non-numeric string is deprecated, use str_increment() instead". This breaks projects that escalate deprecations to exceptions when adding files without explicit handles (e.g. new Pdf([$a, $b])).

Use str_increment() on PHP 8.3+ and fall back to $char++ on older versions, which the library still supports (php >= 8.1). The handle sequence (A, B, ..., Z, AA, ...) is unchanged.

 Fixes #357